### PR TITLE
Add leaderboard to show top 10 scores

### DIFF
--- a/web-ui/components/Leaderboard.tsx
+++ b/web-ui/components/Leaderboard.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect, useMemo } from "react";
+import { AnchorWallet } from "@solana/wallet-adapter-react";
+import { getLeaderboard, LeaderboardItem } from "../lib/clicker-anchor-client";
+import { displayShortPublicKey } from "../lib/utils";
+
+type Props = {
+  wallet: AnchorWallet;
+  endpoint: string;
+  gameAccountPublicKey: string;
+  clicks: number;
+};
+
+export default function Leaderboard({
+  wallet,
+  endpoint,
+  clicks, // current clicks in active game
+}: Props) {
+  const [leaders, setLeaders] = useState<LeaderboardItem[]>([]);
+
+  // retrieve and store expensive leaderboard data (only call when wallet changes)
+  useMemo(async () => {
+    if (wallet) {
+      setLeaders(await getLeaderboard({ wallet, endpoint }));
+    }
+  }, [wallet, endpoint]);
+
+  useEffect(() => {
+    // update current leaderboard with clicks from active game
+    setLeaders(
+      leaders.map((leader) => {
+        if (leader.gameAccountPublicKey === wallet.publicKey.toBase58()) {
+          return {
+            gameAccountPublicKey: leader.gameAccountPublicKey,
+            clicks: clicks,
+          };
+        }
+        return leader;
+      })
+    );
+  }, [clicks]);
+
+  return (
+    <div className="sm:p-10 items-center flex flex-col">
+      <div className="bg-secondary text-secondary-content rounded p-2 mb-4">
+        Top {leaders.length < 10 ? leaders.length : 10}
+      </div>
+      <div className="overflow-x-auto">
+        <table className="table table-zebra w-full">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Player</th>
+              <th>Total Clicks</th>
+            </tr>
+          </thead>
+          <tbody>
+            {leaders.slice(0, 10).map((leader, index) => (
+              <tr key={leader.gameAccountPublicKey}>
+                <th>{index + 1}</th>
+                <td>{displayShortPublicKey(leader.gameAccountPublicKey)}</td>
+                <td className="text-center">{leader.clicks}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/components/Leaderboard.tsx
+++ b/web-ui/components/Leaderboard.tsx
@@ -42,7 +42,7 @@ export default function Leaderboard({
   return (
     <div className="sm:p-10 items-center flex flex-col">
       <div className="bg-secondary text-secondary-content rounded p-2 mb-4">
-        Top {leaders.length < 10 ? leaders.length : 10}
+        Leaderboard
       </div>
       <div className="overflow-x-auto">
         <table className="table table-zebra w-full">
@@ -57,7 +57,11 @@ export default function Leaderboard({
             {leaders.slice(0, 10).map((leader, index) => (
               <tr key={leader.gameAccountPublicKey}>
                 <th>{index + 1}</th>
-                <td>{displayShortPublicKey(leader.gameAccountPublicKey)}</td>
+                <td>
+                  {leader.gameAccountPublicKey === wallet.publicKey.toBase58()
+                    ? "You"
+                    : displayShortPublicKey(leader.gameAccountPublicKey)}
+                </td>
                 <td className="text-center">{leader.clicks}</td>
               </tr>
             ))}

--- a/web-ui/lib/utils.ts
+++ b/web-ui/lib/utils.ts
@@ -1,0 +1,10 @@
+// utils.ts
+
+function displayShortPublicKey(base58: string): string {
+  if (base58.length === 44) {
+    return `0x${base58.slice(0, 4)}..${base58.slice(-4)}`;
+  }
+  return "";
+}
+
+export { displayShortPublicKey };

--- a/web-ui/pages/index.tsx
+++ b/web-ui/pages/index.tsx
@@ -93,7 +93,6 @@ const Home: NextPage = () => {
                   {clicks} clicks
                 </div>
               )}
-              {/* <div>0 cps</div> */}
             </div>
             <button
               disabled={!isGameReady}
@@ -137,7 +136,14 @@ const Home: NextPage = () => {
             )}
           </div>
 
-          {wallet && <Leaderboard wallet={wallet} endpoint={endpoint} gameAccountPublicKey={gameAccountPublicKey} clicks={clicks} />}
+          {wallet && (
+            <Leaderboard
+              wallet={wallet}
+              endpoint={endpoint}
+              gameAccountPublicKey={gameAccountPublicKey}
+              clicks={clicks}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/web-ui/pages/index.tsx
+++ b/web-ui/pages/index.tsx
@@ -7,8 +7,9 @@ import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
 import { useWallet, useAnchorWallet } from "@solana/wallet-adapter-react";
 
 import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
+import Leaderboard from "../components/Leaderboard";
 
-import { isGameInitialized, saveClick } from "../lib/clicker-anchor-client";
+import { getCurrentGame, saveClick } from "../lib/clicker-anchor-client";
 
 const Home: NextPage = () => {
   const [clicks, setClicks] = useState(0);
@@ -17,6 +18,7 @@ const Home: NextPage = () => {
   const [isGameReady, setIsGameReady] = useState(false);
   const [solanaExplorerLink, setSolanaExplorerLink] = useState("");
   const [gameError, setGameError] = useState("");
+  const [gameAccountPublicKey, setGameAccountPublicKey] = useState("");
 
   const { connected } = useWallet();
   const network = WalletAdapterNetwork.Devnet;
@@ -27,7 +29,7 @@ const Home: NextPage = () => {
     setGameError("");
     if (wallet) {
       try {
-        await saveClick({ wallet, endpoint });
+        await saveClick({ wallet, endpoint, gameAccountPublicKey });
         setClicks(clicks + 1);
         setEffect(true);
       } catch (e) {
@@ -41,16 +43,18 @@ const Home: NextPage = () => {
   useEffect(() => {
     async function initGame() {
       if (wallet) {
-        const gameState = await isGameInitialized({ wallet, endpoint });
+        const gameState = await getCurrentGame({ wallet, endpoint });
         setIsGameReady(connected && gameState.isReady);
         setClicks(gameState.clicks);
+        setGameAccountPublicKey(gameState.gameAccountPublicKey);
         setSolanaExplorerLink(
-          `https://explorer.solana.com/address/${gameState.gameAccountPublicKey}/anchor-account?cluster=${network}`
+          `https://explorer.solana.com/address/${gameAccountPublicKey}/anchor-account?cluster=${network}`
         );
         setGameError(gameState.errorMessage);
       } else {
         setIsGameReady(false);
         setClicks(0);
+        setGameAccountPublicKey("");
         setSolanaExplorerLink("");
         setGameError("");
       }
@@ -73,8 +77,8 @@ const Home: NextPage = () => {
       </div>
 
       <div>
-        <div className="flex flex-col sm:flex-row">
-          <div className="p-4 flex flex-col items-center justify-between gap-3">
+        <div className="flex flex-col sm:flex-row gap-5">
+          <div className="p-4 flex flex-col items-center gap-3">
             <div className="flex flex-col items-center p-2">
               {isGameReady && (
                 <div className="m-2 text-red-500">{gameError}</div>
@@ -133,24 +137,8 @@ const Home: NextPage = () => {
             )}
           </div>
 
-          {/* <div className="sm:p-10 items-center flex flex-col justify-between">
-        <h2 className="text-xl font-bold">Extras</h2>
-        <div className="bg-orange-300 m-3 border-0 p-2 shadow-md w-48">
-          auto-clicker one
+          {wallet && <Leaderboard wallet={wallet} endpoint={endpoint} gameAccountPublicKey={gameAccountPublicKey} clicks={clicks} />}
         </div>
-        <div className="bg-pink-300 m-3 border-0 p-2 shadow-md w-48">
-          auto-clicker two
-        </div>
-        <div className="bg-green-300 m-3 border-0 p-2 shadow-md w-48">
-          auto-clicker three
-        </div>
-      </div> */}
-        </div>
-        {/* <div className="p-2 m-3 flex">
-      <div className="bg-blue-300 m-3 w-28 h-16 shadow p-2">bonus one</div>
-      <div className="bg-blue-300 m-3 w-28 h-16 shadow p-2">bonus two</div>
-      <div className="bg-blue-300 m-3 w-28 h-16 shadow p-2">bonus three</div>
-    </div> */}
       </div>
     </div>
   );


### PR DESCRIPTION
Retrieve all games and display top 10 players and scores.

For performance, memoize expensive call, while still updating current user's score in leaderboard as it changes.

Other changes:

- add TypeScript typing for game account data coming back from Anchor
- remove extra network call to retrieve current game each time user Clicks
- remove commented-out unused template fragments