### PR TITLE
Fix: Solana Explorer link was broken

### DIFF
--- a/web-ui/pages/index.tsx
+++ b/web-ui/pages/index.tsx
@@ -61,7 +61,7 @@ const Home: NextPage = () => {
     }
     setIsConnected(connected);
     initGame();
-  }, [connected, endpoint, network, wallet]);
+  }, [connected, endpoint, network, wallet, gameAccountPublicKey]);
 
   return (
     <div className="flex items-center flex-col sm:p-4 p-1">


### PR DESCRIPTION
Fix: Solana Explorer link was broken due to `useEffect` not updating when `gameAccountPublicKey` changed.