### PR TITLE
Fix leaderboard cache. Fix variable naming. Hide leaderboard until data loaded.

### DIFF
--- a/web-ui/components/Leaderboard.tsx
+++ b/web-ui/components/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useRef } from "react";
 import { AnchorWallet } from "@solana/wallet-adapter-react";
 import { getLeaderboard, LeaderboardItem } from "../lib/clicker-anchor-client";
 import { displayShortPublicKey } from "../lib/utils";
@@ -6,7 +6,6 @@ import { displayShortPublicKey } from "../lib/utils";
 type Props = {
   wallet: AnchorWallet;
   endpoint: string;
-  gameAccountPublicKey: string;
   clicks: number;
 };
 
@@ -16,28 +15,27 @@ export default function Leaderboard({
   clicks, // current clicks in active game
 }: Props) {
   const [leaders, setLeaders] = useState<LeaderboardItem[]>([]);
+  const worldGameData = useRef<LeaderboardItem[]>([]);
 
-  // retrieve and store expensive leaderboard data (only call when wallet changes)
-  useMemo(async () => {
-    if (wallet) {
-      setLeaders(await getLeaderboard({ wallet, endpoint }));
-    }
+  // persist expensive "retrieve all game data" call in a Ref
+  useEffect(() => {
+    (async function getLeaderboardData() {
+      if (wallet) {
+        worldGameData.current = await getLeaderboard({ wallet, endpoint });
+        setLeaders(worldGameData.current);
+      }
+    })();
   }, [wallet, endpoint]);
 
+  // update existing leaderboard data with clicks from active game
+  // without reloading from Solana
   useEffect(() => {
-    // update current leaderboard with clicks from active game
-    setLeaders(
-      leaders.map((leader) => {
-        if (leader.gameAccountPublicKey === wallet.publicKey.toBase58()) {
-          return {
-            gameAccountPublicKey: leader.gameAccountPublicKey,
-            clicks: clicks,
-          };
-        }
-        return leader;
-      })
-    );
-  }, [clicks]);
+    worldGameData.current.forEach((game) => {
+      if (game.playerPublicKey === wallet.publicKey.toBase58()) {
+        game.clicks = clicks;
+      }
+    });
+  }, [clicks, wallet.publicKey]);
 
   if (!leaders.length) {
     return null;
@@ -59,12 +57,12 @@ export default function Leaderboard({
           </thead>
           <tbody>
             {leaders.slice(0, 10).map((leader, index) => (
-              <tr key={leader.gameAccountPublicKey}>
+              <tr key={leader.playerPublicKey}>
                 <th>{index + 1}</th>
                 <td>
-                  {leader.gameAccountPublicKey === wallet.publicKey.toBase58()
+                  {leader.playerPublicKey === wallet.publicKey.toBase58()
                     ? "You"
-                    : displayShortPublicKey(leader.gameAccountPublicKey)}
+                    : displayShortPublicKey(leader.playerPublicKey)}
                 </td>
                 <td className="text-center">{leader.clicks}</td>
               </tr>

--- a/web-ui/components/Leaderboard.tsx
+++ b/web-ui/components/Leaderboard.tsx
@@ -39,6 +39,10 @@ export default function Leaderboard({
     );
   }, [clicks]);
 
+  if (!leaders.length) {
+    return null;
+  }
+
   return (
     <div className="sm:p-10 items-center flex flex-col">
       <div className="bg-secondary text-secondary-content rounded p-2 mb-4">

--- a/web-ui/lib/clicker-anchor-client.ts
+++ b/web-ui/lib/clicker-anchor-client.ts
@@ -36,7 +36,7 @@ type GameState = {
 };
 
 export type LeaderboardItem = {
-  gameAccountPublicKey: string;
+  playerPublicKey: string;
   clicks: number;
 };
 
@@ -153,7 +153,7 @@ async function getLeaderboard({
     let games = (await program.account.game.all()) as ClickerGameObject[];
     const unsortedGames = games.map((g) => {
       const item: LeaderboardItem = {
-        gameAccountPublicKey: g.account.player.toString(),
+        playerPublicKey: g.account.player.toString(),
         clicks: g.account.clicks,
       };
       return item;

--- a/web-ui/pages/index.tsx
+++ b/web-ui/pages/index.tsx
@@ -141,12 +141,7 @@ const Home: NextPage = () => {
           </div>
 
           {wallet && (
-            <Leaderboard
-              wallet={wallet}
-              endpoint={endpoint}
-              gameAccountPublicKey={gameAccountPublicKey}
-              clicks={clicks}
-            />
+            <Leaderboard wallet={wallet} endpoint={endpoint} clicks={clicks} />
           )}
         </div>
       </div>


### PR DESCRIPTION
Three fixes:

## Persist Game Data

Mechanism to persist all game data for leaderboard (to avoid expensive network calls) used `useMemo`, plus `useEffect` for only updating that data when clicks are updated for current user was not passing lint.

Problem: And when adding `leaders` dependency to `useEffect` as recommended by link, the leaderboard would never show up since `useMemo` didn't trigger `leaders` to change and update `useEffect`.

Solution: Replaced with `useRef` to hold all game data, then `useEffect` just loops through that and updates when current player registers a click.

## Fix variable naming

Renamed `gameAccountPublicKey` to `playerPublicKey` in `LeaderboardItem` typing and wherever used. That variable wasn't the game account, but rather the player playing that game.

## Avoid flashing Leaderboard in UI when no data

Hide leaderboard in UI until there is data.