### PR TITLE
Refactor Leaderboard and add tests. Fix edge cases.

### DIFF
--- a/web-ui/__tests__/components/Leaderboard.test.tsx
+++ b/web-ui/__tests__/components/Leaderboard.test.tsx
@@ -5,7 +5,7 @@ import { LeaderboardItem } from "@/lib/clicker-anchor-client";
 describe("Leaderboard", () => {
   it("is hidden if there is no data", () => {
     const el = render(
-      <Leaderboard leaders={[]} wallet={{}} endpoint={""} clicks={0} />
+      <Leaderboard leaders={[]} walletPublicKeyString={""} clicks={0} />
     );
 
     expect(el.container).toBeEmptyDOMElement();
@@ -23,7 +23,7 @@ describe("Leaderboard", () => {
     const values = [["1", "0xabcd..effg", 50]];
 
     values.forEach(([rank, shortPublicKey, clicks]) => {
-      const row = screen.getByText(1).closest("tr");
+      const row = screen.getByText(shortPublicKey).closest("tr");
       if (!row) throw new Error("row not found");
       const utils = within(row);
       expect(utils.getByText(rank)).toBeInTheDocument();
@@ -31,7 +31,7 @@ describe("Leaderboard", () => {
       expect(utils.getByText(clicks)).toBeInTheDocument();
     });
 
-    // how many rows are we expecting
+    // how many rows are we expecting?
     const items = await screen.findAllByRole("row");
     expect(items).toHaveLength(2); // tbody tr + one leader
   });
@@ -42,13 +42,252 @@ describe("Leaderboard", () => {
       clicks: 50,
     };
     const el = render(
-      <Leaderboard leaders={[leader]} walletPublicKeyString={"abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg"} clicks={60} />
+      <Leaderboard
+        leaders={[leader]}
+        walletPublicKeyString={"abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg"}
+        clicks={60}
+      />
     );
 
     const values = [["1", "You", 60]];
 
     values.forEach(([rank, shortPublicKey, clicks]) => {
-      const row = screen.getByText(1).closest("tr");
+      const row = screen.getByText(shortPublicKey).closest("tr");
+      if (!row) throw new Error("row not found");
+      const utils = within(row);
+      expect(utils.getByText(rank)).toBeInTheDocument();
+      expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
+      expect(utils.getByText(clicks)).toBeInTheDocument();
+    });
+
+    // how many rows are we expecting?
+    const items = await screen.findAllByRole("row");
+    expect(items).toHaveLength(2); // tbody tr + one leader
+  });
+
+  it("should show multiple rows and be sorted", async () => {
+    const leaders: LeaderboardItem[] = [
+      {
+        playerPublicKey: "3bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+      {
+        playerPublicKey: "1bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 50,
+      },
+      {
+        playerPublicKey: "2bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 20,
+      },
+    ];
+    const el = render(
+      <Leaderboard leaders={leaders} walletPublicKeyString={""} clicks={0} />
+    );
+
+    const values = [
+      ["1", "0x1bcd..effg", 50],
+      ["2", "0x2bcd..effg", 20],
+      ["3", "0x3bcd..effg", 5],
+    ];
+
+    values.forEach(([rank, shortPublicKey, clicks]) => {
+      const row = screen.getByText(shortPublicKey).closest("tr");
+      if (!row) throw new Error("row not found");
+      const utils = within(row);
+      expect(utils.getByText(rank)).toBeInTheDocument();
+      expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
+      expect(utils.getByText(clicks)).toBeInTheDocument();
+    });
+
+    // how many rows are we expecting?
+    const items = await screen.findAllByRole("row");
+    expect(items).toHaveLength(1 + 3); // tbody tr + 3 leaders
+  });
+
+  it("should show maximum of 10 entries", async () => {
+    const leaders: LeaderboardItem[] = [
+      {
+        playerPublicKey: "3bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+      {
+        playerPublicKey: "1bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 50,
+      },
+      {
+        playerPublicKey: "2bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 20,
+      },
+      {
+        playerPublicKey: "4bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+      {
+        playerPublicKey: "5bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+      {
+        playerPublicKey: "6bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+      {
+        playerPublicKey: "7bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+      {
+        playerPublicKey: "8bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+      {
+        playerPublicKey: "9bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+      {
+        playerPublicKey: "10cdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+      {
+        playerPublicKey: "11cdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 5,
+      },
+    ];
+    const el = render(
+      <Leaderboard leaders={leaders} walletPublicKeyString={""} clicks={0} />
+    );
+
+    // how many rows are we expecting?
+    const items = await screen.findAllByRole("row");
+    expect(items).toHaveLength(1 + 10); // tbody tr + 3 leaders
+  });
+
+  describe("when current users clicks", () => {
+    it("and they are in leaderboard, should show new value of clicks", async () => {
+      const leader: LeaderboardItem = {
+        playerPublicKey: "abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 50,
+      };
+      const el = render(
+        <Leaderboard
+          leaders={[leader]}
+          walletPublicKeyString={"abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg"}
+          clicks={60}
+        />
+      );
+
+      const values = [["1", "You", 60]];
+
+      values.forEach(([rank, shortPublicKey, clicks]) => {
+        const row = screen.getByText(shortPublicKey).closest("tr");
+        if (!row) throw new Error("row not found");
+        const utils = within(row);
+        expect(utils.getByText(rank)).toBeInTheDocument();
+        expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
+        expect(utils.getByText(clicks)).toBeInTheDocument();
+      });
+
+      // how many rows are we expecting
+      const items = await screen.findAllByRole("row");
+      expect(items).toHaveLength(2); // tbody tr + one leader
+    });
+
+    it("and they are in leaderboard, and clicks moved them up, should show player in new position", async () => {
+      const leaders: LeaderboardItem[] = [
+        {
+          playerPublicKey: "3bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+          clicks: 5,
+        },
+        {
+          playerPublicKey: "1bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+          clicks: 50,
+        },
+        {
+          playerPublicKey: "2bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+          clicks: 20,
+        },
+      ];
+      const el = render(
+        <Leaderboard
+          leaders={leaders}
+          walletPublicKeyString={"3bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg"}
+          clicks={25}
+        />
+      );
+
+      const values = [
+        ["1", "0x1bcd..effg", 50],
+        ["2", "You", 25],
+        ["3", "0x2bcd..effg", 20],
+      ];
+
+      values.forEach(([rank, shortPublicKey, clicks]) => {
+        const row = screen.getByText(shortPublicKey).closest("tr");
+        if (!row) throw new Error("row not found");
+        const utils = within(row);
+        expect(utils.getByText(rank)).toBeInTheDocument();
+        expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
+        expect(utils.getByText(clicks)).toBeInTheDocument();
+      });
+
+      // how many rows are we expecting?
+      const items = await screen.findAllByRole("row");
+      expect(items).toHaveLength(1 + 3); // tbody tr + 3 leaders
+    });
+    it("and they not in leaderboard since it is first game, should show up if they are in top 10", async () => {
+      const leaders: LeaderboardItem[] = [
+        {
+          playerPublicKey: "1bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+          clicks: 50,
+        },
+        {
+          playerPublicKey: "2bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+          clicks: 20,
+        },
+      ];
+      const el = render(
+        <Leaderboard
+          leaders={leaders}
+          walletPublicKeyString={"3bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg"}
+          clicks={1}
+        />
+      );
+
+      const values = [
+        ["1", "0x1bcd..effg", 50],
+        ["2", "0x2bcd..effg", 20],
+        ["3", "You", 1],
+      ];
+
+      values.forEach(([rank, shortPublicKey, clicks]) => {
+        const row = screen.getByText(shortPublicKey).closest("tr");
+        if (!row) throw new Error("row not found");
+        const utils = within(row);
+        expect(utils.getByText(rank)).toBeInTheDocument();
+        expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
+        expect(utils.getByText(clicks)).toBeInTheDocument();
+      });
+
+      // how many rows are we expecting?
+      const items = await screen.findAllByRole("row");
+      expect(items).toHaveLength(1 + 3); // tbody tr + 3 leaders
+    });
+  });
+
+  it('if "leaders" prop changes, component should re-render with new data (to ensure useEffect has `leaders` dependency)', async () => {
+    // this bug prevents the leaderboard from rendering, so adding test to ensure this doesn't crop up
+    const leaders: LeaderboardItem[] = [
+      {
+        playerPublicKey: "1bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 50,
+      },
+    ];
+
+    const { rerender } = render(
+      <Leaderboard leaders={leaders} walletPublicKeyString={""} clicks={1} />
+    );
+    const values = [["1", "0x1bcd..effg", 50]];
+
+    values.forEach(([rank, shortPublicKey, clicks]) => {
+      const row = screen.getByText(shortPublicKey).closest("tr");
       if (!row) throw new Error("row not found");
       const utils = within(row);
       expect(utils.getByText(rank)).toBeInTheDocument();
@@ -59,44 +298,35 @@ describe("Leaderboard", () => {
     // how many rows are we expecting
     const items = await screen.findAllByRole("row");
     expect(items).toHaveLength(2); // tbody tr + one leader
-  });
 
-  it.todo("should show multiple rows and be sorted");
-  it.todo("should only show top 10");
+    //
+    // re-render the same component with different props
+    //
 
-  it.todo("should say 'You' if playerPublicKey matches current wallet PublicKey");
+    const leaders2: LeaderboardItem[] = [
+      {
+        playerPublicKey: "2bcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 20,
+      },
+    ];
 
-  describe("when current users clicks", () => {
-    it("and they are in leaderboard, should show new value of clicks", async () => {
-      const leader: LeaderboardItem = {
-        playerPublicKey: "abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
-        clicks: 50,
-      };
-      const el = render(
-        <Leaderboard leaders={[leader]} walletPublicKeyString={"abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg"} clicks={60} />
-      );
-  
-      const values = [["1", "You", 60]];
-  
-      values.forEach(([rank, shortPublicKey, clicks]) => {
-        const row = screen.getByText(1).closest("tr");
-        if (!row) throw new Error("row not found");
-        const utils = within(row);
-        expect(utils.getByText(rank)).toBeInTheDocument();
-        expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
-        expect(utils.getByText(clicks)).toBeInTheDocument();
-      });
-  
-      // how many rows are we expecting
-      const items = await screen.findAllByRole("row");
-      expect(items).toHaveLength(2); // tbody tr + one leader
+    rerender(
+      <Leaderboard leaders={leaders2} walletPublicKeyString={""} clicks={1} />
+    );
+
+    const values2 = [["1", "0x2bcd..effg", 20]];
+
+    values2.forEach(([rank, shortPublicKey, clicks]) => {
+      const row = screen.getByText(shortPublicKey).closest("tr");
+      if (!row) throw new Error("row not found");
+      const utils = within(row);
+      expect(utils.getByText(rank)).toBeInTheDocument();
+      expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
+      expect(utils.getByText(clicks)).toBeInTheDocument();
     });
 
-    it.todo(
-      "and they are in leaderboard, and clicks moved them up, should show player in new position"
-    );
-    it.todo(
-      "and they not in leaderboard since it is first game, should show up if they are in top 10"
-    );
+    // how many rows are we expecting
+    const items2 = await screen.findAllByRole("row");
+    expect(items2).toHaveLength(2); // tbody tr + one leader
   });
 });

--- a/web-ui/__tests__/components/Leaderboard.test.tsx
+++ b/web-ui/__tests__/components/Leaderboard.test.tsx
@@ -1,0 +1,102 @@
+import { getByRole, render, screen, within } from "@testing-library/react";
+import Leaderboard from "@/components/Leaderboard";
+import { LeaderboardItem } from "@/lib/clicker-anchor-client";
+
+describe("Leaderboard", () => {
+  it("is hidden if there is no data", () => {
+    const el = render(
+      <Leaderboard leaders={[]} wallet={{}} endpoint={""} clicks={0} />
+    );
+
+    expect(el.container).toBeEmptyDOMElement();
+  });
+
+  it("displays one leader with their short public key (if user is not current player)", async () => {
+    const leader: LeaderboardItem = {
+      playerPublicKey: "abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+      clicks: 50,
+    };
+    const el = render(
+      <Leaderboard leaders={[leader]} walletPublicKeyString={""} clicks={0} />
+    );
+
+    const values = [["1", "0xabcd..effg", 50]];
+
+    values.forEach(([rank, shortPublicKey, clicks]) => {
+      const row = screen.getByText(1).closest("tr");
+      if (!row) throw new Error("row not found");
+      const utils = within(row);
+      expect(utils.getByText(rank)).toBeInTheDocument();
+      expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
+      expect(utils.getByText(clicks)).toBeInTheDocument();
+    });
+
+    // how many rows are we expecting
+    const items = await screen.findAllByRole("row");
+    expect(items).toHaveLength(2); // tbody tr + one leader
+  });
+
+  it("displays one leader with 'You' instead of their short public key (if user is current player)", async () => {
+    const leader: LeaderboardItem = {
+      playerPublicKey: "abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+      clicks: 50,
+    };
+    const el = render(
+      <Leaderboard leaders={[leader]} walletPublicKeyString={"abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg"} clicks={60} />
+    );
+
+    const values = [["1", "You", 60]];
+
+    values.forEach(([rank, shortPublicKey, clicks]) => {
+      const row = screen.getByText(1).closest("tr");
+      if (!row) throw new Error("row not found");
+      const utils = within(row);
+      expect(utils.getByText(rank)).toBeInTheDocument();
+      expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
+      expect(utils.getByText(clicks)).toBeInTheDocument();
+    });
+
+    // how many rows are we expecting
+    const items = await screen.findAllByRole("row");
+    expect(items).toHaveLength(2); // tbody tr + one leader
+  });
+
+  it.todo("should show multiple rows and be sorted");
+  it.todo("should only show top 10");
+
+  it.todo("should say 'You' if playerPublicKey matches current wallet PublicKey");
+
+  describe("when current users clicks", () => {
+    it("and they are in leaderboard, should show new value of clicks", async () => {
+      const leader: LeaderboardItem = {
+        playerPublicKey: "abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg",
+        clicks: 50,
+      };
+      const el = render(
+        <Leaderboard leaders={[leader]} walletPublicKeyString={"abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg"} clicks={60} />
+      );
+  
+      const values = [["1", "You", 60]];
+  
+      values.forEach(([rank, shortPublicKey, clicks]) => {
+        const row = screen.getByText(1).closest("tr");
+        if (!row) throw new Error("row not found");
+        const utils = within(row);
+        expect(utils.getByText(rank)).toBeInTheDocument();
+        expect(utils.getByText(shortPublicKey)).toBeInTheDocument();
+        expect(utils.getByText(clicks)).toBeInTheDocument();
+      });
+  
+      // how many rows are we expecting
+      const items = await screen.findAllByRole("row");
+      expect(items).toHaveLength(2); // tbody tr + one leader
+    });
+
+    it.todo(
+      "and they are in leaderboard, and clicks moved them up, should show player in new position"
+    );
+    it.todo(
+      "and they not in leaderboard since it is first game, should show up if they are in top 10"
+    );
+  });
+});

--- a/web-ui/__tests__/lib/utils.test.ts
+++ b/web-ui/__tests__/lib/utils.test.ts
@@ -8,9 +8,9 @@ describe("Utils", () => {
     });
 
     it("displays empty shortened string if valid base58 value", () => {
-      const pk = "abcdefghijklmnopqrstuvwxyz01234567890abcdefg";
+      const pk = "abcdefabcdefabcdefabcdefabcdefabcdefabcdeffg";
       const result = displayShortPublicKey(pk);
-      expect(result).toBe("0xabcd..defg");
+      expect(result).toBe("0xabcd..effg");
     });
   });
 });

--- a/web-ui/components/Leaderboard.tsx
+++ b/web-ui/components/Leaderboard.tsx
@@ -18,18 +18,30 @@ export default function Leaderboard({
   // update existing leaderboard data with clicks from active game
   // without reloading from Solana
   useEffect(() => {
-    setDisplayLeaders(
-      leaders.map((leader) => {
-        if (leader.playerPublicKey === walletPublicKeyString) {
-          return {
-            playerPublicKey: leader.playerPublicKey,
-            clicks: clicks,
-          };
-        }
-        return leader;
-      })
-    );
-  }, [clicks, walletPublicKeyString]);
+    let foundCurrentUser = false;
+    const updatedLeaders = leaders.map((leader) => {
+      if (leader.playerPublicKey === walletPublicKeyString) {
+        foundCurrentUser = true;
+        return {
+          playerPublicKey: leader.playerPublicKey,
+          clicks: clicks,
+        };
+      }
+      return leader;
+    });
+
+    // if users first game (and they aren't in list of games retrieved) add 'em
+    if (walletPublicKeyString && clicks && !foundCurrentUser) {
+      updatedLeaders.push({
+        playerPublicKey: walletPublicKeyString,
+        clicks: clicks,
+      });
+    }
+
+    // sort by leader
+    const sortByClicks = updatedLeaders.sort((a, b) => b.clicks - a.clicks);
+    setDisplayLeaders(sortByClicks);
+  }, [clicks, walletPublicKeyString, leaders]);
 
   if (!displayLeaders.length) {
     return null;
@@ -53,10 +65,12 @@ export default function Leaderboard({
             {displayLeaders.slice(0, 10).map((leader, index) => (
               <tr key={leader.playerPublicKey}>
                 <th>{index + 1}</th>
-                <td>
-                  {leader.playerPublicKey === walletPublicKeyString
-                    ? "You"
-                    : displayShortPublicKey(leader.playerPublicKey)}
+                <td className="text-center">
+                  {leader.playerPublicKey === walletPublicKeyString ? (
+                    <b>You</b>
+                  ) : (
+                    displayShortPublicKey(leader.playerPublicKey)
+                  )}
                 </td>
                 <td className="text-center">{leader.clicks}</td>
               </tr>

--- a/web-ui/lib/clicker-anchor-client.ts
+++ b/web-ui/lib/clicker-anchor-client.ts
@@ -151,14 +151,13 @@ async function getLeaderboard({
   try {
     const program = await getProgram({ wallet, endpoint });
     let games = (await program.account.game.all()) as ClickerGameObject[];
-    const unsortedGames = games.map((g) => {
+    return games.map((g) => {
       const item: LeaderboardItem = {
         playerPublicKey: g.account.player.toString(),
         clicks: g.account.clicks,
       };
       return item;
     });
-    return unsortedGames.sort((a, b) => b.clicks - a.clicks);
   } catch (e) {
     console.error("problem retrieving games");
   }

--- a/web-ui/pages/index.tsx
+++ b/web-ui/pages/index.tsx
@@ -92,7 +92,6 @@ const Home: NextPage = () => {
   useEffect(() => {
     (async function getLeaderboardData() {
       if (wallet) {
-        console.log("EXPENSIVE");
         setLeaders(await getLeaderboard({ wallet, endpoint }));
       }
     })();

--- a/web-ui/pages/index.tsx
+++ b/web-ui/pages/index.tsx
@@ -8,6 +8,7 @@ import { useWallet, useAnchorWallet } from "@solana/wallet-adapter-react";
 
 import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
 import Leaderboard from "@/components/Leaderboard";
+import { getLeaderboard, LeaderboardItem } from "@/lib/clicker-anchor-client";
 
 import {
   airdrop,
@@ -26,6 +27,7 @@ const Home: NextPage = () => {
   const [solanaExplorerLink, setSolanaExplorerLink] = useState("");
   const [gameError, setGameError] = useState("");
   const [gameAccountPublicKey, setGameAccountPublicKey] = useState("");
+  const [leaders, setLeaders] = useState<LeaderboardItem[]>([]);
 
   const { connected } = useWallet();
   const network = WalletAdapterNetwork.Devnet;
@@ -85,6 +87,16 @@ const Home: NextPage = () => {
     }
     fetchTestSol();
   }, [connected, wallet, endpoint]);
+
+  // For leaderboard, persist expensive "retrieve all game data" via useState()
+  useEffect(() => {
+    (async function getLeaderboardData() {
+      if (wallet) {
+        console.log("EXPENSIVE");
+        setLeaders(await getLeaderboard({ wallet, endpoint }));
+      }
+    })();
+  }, [wallet, endpoint]);
 
   return (
     <div className="flex items-center flex-col sm:p-4 p-1">
@@ -186,7 +198,11 @@ const Home: NextPage = () => {
           </div>
 
           {wallet && (
-            <Leaderboard wallet={wallet} endpoint={endpoint} clicks={clicks} />
+            <Leaderboard
+              leaders={leaders}
+              walletPublicKeyString={wallet.publicKey.toBase58()}
+              clicks={clicks}
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
As a result, the `<Leaderboard />` component much more lean and well-tested.

## Refactor Leaderboard and add initial tests.

- [x] #22 - pull Solana data retrieval logic out of Leaderboard and pass it in as a dependency, simplifying component and making it easy to test.
- [x] Finish pending tests

## Fix edge cases

- [x] #25

Close #22. Closes #25.